### PR TITLE
Improved checking for homepage and usage of .Site.BaseURL

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,4 +1,3 @@
-{{ $baseUrl := .Site.BaseURL }}
 {{ partial "header.html" . }}
 
 <main role="main">
@@ -22,7 +21,7 @@
 <hr />
 
 <div class="row doc-main text-center">
-	<a href="{{ $baseUrl }}/post">See posts for {{ .Site.Title }}</a>
+	<a href="{{ .Site.BaseURL }}post">See posts for {{ .Site.Title }}</a>
 </div>
 {{ end }}
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,4 +1,3 @@
-{{ $baseUrl := .Site.BaseURL }}
 <hr />
 
 <div class="row">
@@ -24,12 +23,12 @@
 	ga('send', 'pageview');
 </script>{{ end }}
 
-<script src="{{ $baseUrl }}/js/jquery-1.11.2.min.js"></script>
-<script src="{{ $baseUrl }}/js/bootstrap.min.js"></script>
+<script src="{{ .Site.BaseURL }}js/jquery-1.11.2.min.js"></script>
+<script src="{{ .Site.BaseURL }}js/bootstrap.min.js"></script>
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-<script src="{{ $baseUrl }}/js/highlight.min.js"></script>
+<script src="{{ .Site.BaseURL }}js/highlight.min.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
-<script src="{{ $baseUrl }}/js/ie10-viewport-bug-workaround.js"></script>
+<script src="{{ .Site.BaseURL }}js/ie10-viewport-bug-workaround.js"></script>
 
 </body>
 </html>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-{{ $isHomePage := eq (relURL .URL) ("/" | safeHTML) }}
+{{ $isHomepage := (eq .Permalink (print .Site.BaseURL | safeHTML)) }}
 <html lang="en">
 	<head>
 		<meta charset="utf-8">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,19 +1,18 @@
 <!DOCTYPE html>
-{{ $baseUrl := .Site.BaseURL }}
 {{ $isHomePage := eq .Title .Site.Title }}
 <html lang="en">
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<link rel="alternate" href="/index.xml" type="application/rss+xml" title="{{ .Site.Title }}">
-		<link rel="icon" href="{{ $baseUrl }}/favicon.ico">
+		<link rel="alternate" href="{{ .Site.BaseURL }}index.xml" type="application/rss+xml" title="{{ .Site.Title }}">
+		<link rel="icon" href="{{ .Site.BaseURL }}favicon.ico">
 		<title>{{ .Title }}{{ if eq $isHomePage false }} - {{ .Site.Title }}{{ end }}</title>
 		<!--<link href="http://fonts.googleapis.com/css?family=PT+Sans:400,700" rel="stylesheet" type="text/css">-->
-		<link rel="stylesheet" href="{{ $baseUrl }}/css/highlight.js.min.css">
-		<link rel="stylesheet" href="{{ $baseUrl }}/css/bootstrap.min.css">
-		<link rel="stylesheet" href="{{ $baseUrl }}/css/bootstrap-theme.css">
-		<link rel="stylesheet" href="{{ $baseUrl }}/css/theme.css">
-		<link rel="stylesheet" href="{{ $baseUrl }}/css/bootie-docs.css">
+		<link rel="stylesheet" href="{{ .Site.BaseURL }}css/highlight.js.min.css">
+		<link rel="stylesheet" href="{{ .Site.BaseURL }}css/bootstrap.min.css">
+		<link rel="stylesheet" href="{{ .Site.BaseURL }}css/bootstrap-theme.css">
+		<link rel="stylesheet" href="{{ .Site.BaseURL }}css/theme.css">
+		<link rel="stylesheet" href="{{ .Site.BaseURL }}css/bootie-docs.css">
 	</head>
 
 <body role="document">
@@ -28,16 +27,16 @@
 					<span class="icon-bar"></span>
 					<span class="icon-bar"></span>
 				</button>
-				<a class="navbar-brand" href="{{ $baseUrl }}/">{{ .Site.Title }}</a>
+				<a class="navbar-brand" href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
 			</div>
 			<div id="navbar" class="navbar-collapse collapse">
 				<ul class="nav navbar-nav">
-					<li {{ if eq $isHomePage true }}class="active"{{ end }}><a href="{{ $baseUrl }}/">Home</a></li>
+					<li {{ if eq $isHomePage true }}class="active"{{ end }}><a href="{{ .Site.BaseURL }}">Home</a></li>
 			{{ if isset .Site.Params "mainMenu" }}
 				{{ $url := .Permalink }}
 				{{ range $item := .Site.Params.mainMenu }}
-					{{ $itemUrl := printf "%s/%s/" $baseUrl $item }}
-					<li {{ if eq $url $itemUrl }}class="active"{{ end }}><a href="{{ $baseUrl }}/{{ $item }}">{{ title $item }}</a></li>
+					{{ $itemUrl := printf "%s/%s/" .Site.BaseURL $item }}
+					<li {{ if eq $url $itemUrl }}class="active"{{ end }}><a href="{{ .Site.BaseURL }}{{ $item }}">{{ title $item }}</a></li>
 				{{ end }}
 			{{ end }}
 				{{ if isset .Site.Params "noCategoryLink" }}{{ else }}
@@ -45,7 +44,7 @@
 						<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Categories<span class="caret"></span></a>
 						<ul class="dropdown-menu" role="menu">
 						{{ range $name, $taxonomy := .Site.Taxonomies.categories }}
-							<li><a href="{{ $baseUrl }}/categories/{{ $name | urlize }}">{{ title $name }}</a></li>
+							<li><a href="{{ .Site.BaseURL }}categories/{{ $name | urlize }}">{{ title $name }}</a></li>
 						{{ end }}
 						</ul>
 					</li>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-{{ $isHomePage := eq .Title .Site.Title }}
+{{ $isHomePage := eq (relURL .URL) ("/" | safeHTML) }}
 <html lang="en">
 	<head>
 		<meta charset="utf-8">

--- a/layouts/partials/sidebar-list.html
+++ b/layouts/partials/sidebar-list.html
@@ -1,10 +1,9 @@
-{{ $baseUrl := .Site.BaseURL }}
 <div class="col-sm-3 col-sm-offset-1 doc-sidebar">
 	<div class="sidebar-module">
 		<h4>Categories</h4>
 		<ul class="list-unstyled">
 		{{ range $name, $taxonomy := .Site.Taxonomies.categories }}
-			<li><a class="tag-item" href="{{ $baseUrl }}/categories/{{ $name | urlize }}">{{ $name }}</a></li>
+			<li><a class="tag-item" href="{{ .Site.BaseURL }}categories/{{ $name | urlize }}">{{ $name }}</a></li>
 		{{ end }}
 		</ul>
 	</div>
@@ -12,7 +11,7 @@
 		<h4>Tags</h4>
 		<div class="tag-box">
 		{{ range $name, $taxonomy := .Site.Taxonomies.tags }}
-			<a class="tag-item" href="{{ $baseUrl }}/tags/{{ $name | urlize }}">{{ $name }}</a>
+			<a class="tag-item" href="{{ .Site.BaseURL }}tags/{{ $name | urlize }}">{{ $name }}</a>
 		{{ end }}
 		</div>
 	</div>

--- a/layouts/partials/sidebar-single.html
+++ b/layouts/partials/sidebar-single.html
@@ -1,4 +1,3 @@
-{{ $baseUrl := .Site.BaseURL }}
 <div class="col-sm-3 col-sm-offset-1 doc-sidebar">
 	<div class="sidebar-module">
 		<div class="sidebar-toc">
@@ -13,7 +12,7 @@
 		<h4>Tags</h4>
 		<div class="tag-box">
 		{{ range $name, $taxonomy := .Site.Taxonomies.tags }}
-			<a class="tag-item" href="{{ $baseUrl }}/tags/{{ $name | urlize }}">{{ $name }}</a>
+			<a class="tag-item" href="{{ .Site.BaseURL }}tags/{{ $name | urlize }}">{{ $name }}</a>
 		{{ end }}
 		</div>
 	</div>

--- a/theme.toml
+++ b/theme.toml
@@ -4,15 +4,9 @@ licenselink = "https://github.com/key-amb/hugo-theme-bootie-docs/LICENSE.md"
 description = "A simple Hugo theme with Bootstrap for documentation"
 homepage = "http://key-amb.github.io/bootie-docs-demo/"
 tags = ["document", "bootstrap"]
-features = ["document", ""]
+features = ["document"]
 min_version = 0.14
 
 [author]
   name = "YASUTAKE Kiyoshi"
   homepage = "https://github.com/key-amb"
-
-# If porting an existing theme
-[original]
-  name = ""
-  homepage = ""
-  repo = ""

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,6 @@
+box: debian
+build:
+  steps:
+    - samueldebruyn/hugo-theme-check:
+        version: "0.14"
+        theme: material-lite


### PR DESCRIPTION
There's no need to create a variable containing `.Site.BaseURL`.

Also, baseURL should not contain a trailing slash, so adding one after every mention of `.Site.BaseURL` causes double slashes (e.g. _http://example.org//myfile.html_)

There's no guarantee that `.Title` is different from `.Site.Title` on a post page. Hugo v0.15 will contain `.IsHome`, but meanwhile `eq (relURL .URL) ("/" | safeHTML)` is [recommended](http://discuss.gohugo.io/t/how-to-check-for-home-page/149/17).
