### PR TITLE
Change: show page hierarchy by category in all pages

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,6 +18,29 @@
 	</div>
 {{ end }}
 
+<div class="row doc-category">
+	<h2>Pages in Categories</h2>
+	<div>
+		<ul class="doc-list-category">
+		{{ range $name, $taxonomy := .Site.Taxonomies.categories }}
+			<li>
+				<a href="{{ $baseUrl }}/categories/{{ $name | urlize }}">
+					<span class="doc-list-category">{{ $name | title }}</span>
+				</a>
+				<ul>{{ range $taxonomy.Pages }}
+					<li><a href="{{ .RelPermalink }}">
+						<span>{{ .Title }}{{ if .Draft }} #Draft{{ end }}</span>
+						<span class="doc-entry-meta">(<time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "January 02, 2006" }}</time>)
+					</span>
+				</a></li>
+				{{ end }}
+				</ul>
+			</li>
+		{{ end }}
+		</ul>
+	</div>
+</div>
+
 {{ if isset .Site.Params "withSitePosts" }}
 <hr />
 

--- a/layouts/partials/sidebar-list.html
+++ b/layouts/partials/sidebar-list.html
@@ -1,15 +1,23 @@
 {{ $baseUrl := .Site.BaseURL }}
 <div class="col-sm-3 col-sm-offset-1 doc-sidebar">
 	<div class="sidebar-module">
-		<h4>Categories</h4>
-		<ul class="list-unstyled">
+		<h4 class="sidebar-heading">Pages in Categories</h4>
+		<ul class="sidebar-category-list">
 		{{ range $name, $taxonomy := .Site.Taxonomies.categories }}
-			<li><a class="tag-item" href="{{ $baseUrl }}/categories/{{ $name | urlize }}">{{ $name }}</a></li>
+			<li>
+				<a href="{{ $baseUrl }}/categories/{{ $name | urlize }}">
+					<span class="doc-list-category">{{ $name | title }}</span>
+				</a>
+				<ul>{{ range $taxonomy.Pages }}
+					<li><a href="{{ .RelPermalink }}">{{ .Title }}{{ if .Draft }} #Draft{{ end }}</a></li>
+				{{ end }}
+				</ul>
+			</li>
 		{{ end }}
 		</ul>
 	</div>
 	<div class="sidebar-module">
-		<h4>Tags</h4>
+		<h4 class="sidebar-heading">Tags</h4>
 		<div class="tag-box">
 		{{ range $name, $taxonomy := .Site.Taxonomies.tags }}
 			<a class="tag-item" href="{{ $baseUrl }}/tags/{{ $name | urlize }}">{{ $name }}</a>

--- a/layouts/partials/sidebar-single.html
+++ b/layouts/partials/sidebar-single.html
@@ -1,9 +1,10 @@
 {{ $baseUrl := .Site.BaseURL }}
+{{ $url := .Permalink }}
 <div class="col-sm-3 col-sm-offset-1 doc-sidebar">
 	<div id="sidebar">
 	<div class="sidebar-module">
 		<div class="sidebar-toc">
-			<h4>Table of Contents</h4>
+			<h4 class="sidebar-heading">Table of Contents</h4>
 			<ul>
 				<li><strong><a href="#title">{{ .Title }}</a></strong></li>
 			</ul>
@@ -11,7 +12,26 @@
 		</div>
 	</div>
 	<div class="sidebar-module">
-		<h4>Tags</h4>
+		<h4 class="sidebar-heading">Pages in Categories</h4>
+		<ul class="sidebar-category-list">
+		{{ range $name, $taxonomy := .Site.Taxonomies.categories }}
+			<li>
+				<a href="{{ $baseUrl }}/categories/{{ $name | urlize }}">
+					<span class="doc-list-category">{{ $name | title }}</span>
+				</a>
+				<ul>{{ range $taxonomy.Pages }}
+					<li>{{ if eq $url .Permalink }}
+						<span class="active">{{ .Title }}{{ if .Draft }} #Draft{{ end }}</span>
+						{{ else }}<a href="{{ .RelPermalink }}">{{ .Title }}{{ if .Draft }} #Draft{{ end }}</a>
+					{{ end }}</li>
+				{{ end }}
+				</ul>
+			</li>
+		{{ end }}
+		</ul>
+	</div>
+	<div class="sidebar-module">
+		<h4 class="sidebar-heading">Tags</h4>
 		<div class="tag-box">
 		{{ range $name, $taxonomy := .Site.Taxonomies.tags }}
 			<a class="tag-item" href="{{ $baseUrl }}/tags/{{ $name | urlize }}">{{ $name }}</a>

--- a/static/css/bootie-docs.css
+++ b/static/css/bootie-docs.css
@@ -109,6 +109,9 @@ div.doc-search-form {
 .doc-main pre code {
   font-size: 14px;
 }
+div.doc-main {
+  margin-bottom: 20px;
+}
 
 /* List items */
 .doc-list-header {
@@ -133,6 +136,13 @@ div.doc-search-form {
 span.doc-list-category {
   font-style: italic;
   background-color: #f5f5ff;
+}
+ul.doc-list-category > li {
+  font-size: 20px;
+}
+ul.doc-list-category > li > ul > li {
+  font-size: 18px;
+  font-style: normal;
 }
 
 /* Tables */

--- a/static/css/bootie-docs.css
+++ b/static/css/bootie-docs.css
@@ -130,6 +130,10 @@ div.doc-search-form {
 .doc-entry-meta.in-list {
   font-size: 80%;
 }
+span.doc-list-category {
+  font-style: italic;
+  background-color: #f5f5ff;
+}
 
 /* Tables */
 main > article > section > table {
@@ -194,8 +198,11 @@ div#sidebar {
 
 /* Sidebar modules for boxing content */
 .sidebar-module {
-  padding: 15px;
+  padding: 0px 15px 5px;
   margin: 0 -15px 15px;
+}
+.sidebar-heading {
+  border-bottom: 1px solid #eee;
 }
 .sidebar-module-inset {
   padding: 15px;
@@ -212,6 +219,25 @@ div#sidebar {
   list-style-position: outside;
   margin-left: -1.5em;
   padding: 0;
+}
+
+ul.sidebar-category-list > li {
+  list-style-type: none;
+  margin-left: -1.5em;
+  font-size: 15px;
+}
+ul.sidebar-category-list > li,
+ul.sidebar-category-list > li > ul > li {
+  list-style-position: outside;
+  padding: 0;
+}
+ul.sidebar-category-list > li > ul > li {
+  font-size: 14px;
+  font-style: normal;
+}
+ul.sidebar-category-list > li > ul > li > span.active {
+  color: #999;
+  font-weight: 500;
 }
 
 .tag-box {
@@ -257,4 +283,3 @@ div#sidebar {
 .doc-footer-em {
   font-size: 16px;
 }
-

--- a/static/js/bootie-docs.js
+++ b/static/js/bootie-docs.js
@@ -22,7 +22,7 @@ window.onload = function() {
         sideNode.css({"position": "fixed", "top": headHeight + 20 + "px"});
       } else if (w.scrollTop() >= scrollStop) {
         var topNext
-          = headHeight - (headHeight + sideHeight)
+          = headHeight - (headHeight + sideHeight + footHeight)
             * (w.scrollTop() - scrollStop) / (totalHeight - scrollStop);
         sideNode.css({
           "position": "fixed", "top": topNext + "px", "bottom": footHeight + "px"


### PR DESCRIPTION
At ...
- bottom of top page
- sidebars in both single page and listing page

Improve:
- https://github.com/key-amb/hugo-theme-bootie-docs/pull/15/commits/5728b94beac6e28c353970dfb2024d5d509263d9
