### PR TITLE
Fix #18 / .Site.Params "fooBar" is not accessible for Hugo v0.18

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,7 +7,7 @@
 	<!-- Main jumbotron for a primary marketing message or call to action -->
 	<div class="jumbotron">
 		<h1>{{ .Site.Title }}</h1>
-		<p>{{ if isset .Site.Params "description" }}{{ .Site.Params.description }}{{ else }}You can customize this text by params "description" in your <code>config.toml</code>.{{ end }}</p>
+		<p>{{ if .Site.Params.description }}{{ .Site.Params.description }}{{ else }}You can customize this text by params "description" in your <code>config.toml</code>.{{ end }}</p>
 	</div>
 </div>
 
@@ -41,7 +41,7 @@
 	</div>
 </div>
 
-{{ if isset .Site.Params "withSitePosts" }}
+{{ if .Site.Params.withSitePosts }}
 <hr />
 
 <div class="row doc-main text-center">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,7 +7,7 @@
 	<!-- Main jumbotron for a primary marketing message or call to action -->
 	<div class="jumbotron">
 		<h1>{{ .Site.Title }}</h1>
-		<p>{{ if .Site.Params.description }}{{ .Site.Params.description }}{{ else }}You can customize this text by params "description" in your <code>config.toml</code>.{{ end }}</p>
+		<p>{{ with .Site.Params.description }}{{ . }}{{ else }}You can customize this text by params "description" in your <code>config.toml</code>.{{ end }}</p>
 	</div>
 </div>
 
@@ -41,11 +41,12 @@
 	</div>
 </div>
 
-{{ if .Site.Params.withSitePosts }}
+{{ $title := .Site.Title }}
+{{ with .Site.Params.withSitePosts }}
 <hr />
 
 <div class="row doc-main text-center">
-	<a href="{{ $baseUrl }}/post">See posts for {{ .Site.Title }}</a>
+	<a href="{{ $baseUrl }}/post">See posts for {{ $title }}</a>
 </div>
 {{ end }}
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -9,7 +9,7 @@
 		<link rel="icon" href="{{ $baseUrl }}/favicon.ico">
 		<title>{{ .Title }}{{ if eq $isHomePage false }} - {{ .Site.Title }}{{ end }}</title>
 		<!--<link href="http://fonts.googleapis.com/css?family=PT+Sans:400,700" rel="stylesheet" type="text/css">-->
-		<link rel="stylesheet" href="{{ $baseUrl }}/css/highlight/{{ if .Site.Params.highlightStyle }}{{ .Site.Params.highlightStyle }}{{ else }}default{{ end }}.css">
+		<link rel="stylesheet" href="{{ $baseUrl }}/css/highlight/{{ with .Site.Params.highlightStyle }}{{ . }}{{ else }}default{{ end }}.css">
 		<link rel="stylesheet" href="{{ $baseUrl }}/css/bootstrap.min.css">
 		<link rel="stylesheet" href="{{ $baseUrl }}/css/bootstrap-theme.min.css">
 		<link rel="stylesheet" href="{{ $baseUrl }}/css/theme.css">
@@ -33,14 +33,14 @@
 			<div id="navbar" class="navbar-collapse collapse">
 				<ul class="nav navbar-nav">
 					<li {{ if eq $isHomePage true }}class="active"{{ end }}><a href="{{ $baseUrl }}/">Home</a></li>
-			{{ if .Site.Params.mainMenu }}
-				{{ $url := .Permalink }}
-				{{ range $menu := .Site.Params.mainMenu }}
+			{{ $url := .Permalink }}
+			{{ with .Site.Params.mainMenu }}
+				{{ range $menu := . }}
 					{{ $itemUrl := printf "%s/%s/" $baseUrl $menu.link }}
 					<li {{ if eq $url $itemUrl }}class="active"{{ end }}><a href="{{ $baseUrl }}/{{ $menu.link }}">{{ $menu.name }}</a></li>
 				{{ end }}
 			{{ end }}
-				{{ if .Site.Params.noCategoryLink }}{{ else }}
+				{{ if not .Site.Params.noCategoryLink }}
 					<li class="dropdown">
 						<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Categories<span class="caret"></span></a>
 						<ul class="dropdown-menu" role="menu">
@@ -51,10 +51,10 @@
 					</li>
 				{{ end }}
 				</ul>
-				{{ if .Site.Params.searchDomain }}
+				{{ with .Site.Params.searchDomain }}
 				<form class="navbar-form navbar-left" role="search" action="https://www.google.co.jp/search" method="get">
 					<div class="input-group doc-search-form">
-						<input type="hidden" name="as_sitesearch" value="{{ .Site.Params.searchDomain }}">
+						<input type="hidden" name="as_sitesearch" value="{{ . }}">
 						<input type="text" name="as_q" class="search-query doc-search-input-text" placeholder="Search Site">
 						<span class="input-group-addon input-group-btn doc-search-input-btn">
 							<button class="btn" type="submit"><span class="glyphicon glyphicon-search"></span></button>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -9,7 +9,7 @@
 		<link rel="icon" href="{{ $baseUrl }}/favicon.ico">
 		<title>{{ .Title }}{{ if eq $isHomePage false }} - {{ .Site.Title }}{{ end }}</title>
 		<!--<link href="http://fonts.googleapis.com/css?family=PT+Sans:400,700" rel="stylesheet" type="text/css">-->
-		<link rel="stylesheet" href="{{ $baseUrl }}/css/highlight/{{ if isset .Site.Params "highlightStyle" }}{{ .Site.Params.highlightStyle }}{{ else }}default{{ end }}.css">
+		<link rel="stylesheet" href="{{ $baseUrl }}/css/highlight/{{ if .Site.Params.highlightStyle }}{{ .Site.Params.highlightStyle }}{{ else }}default{{ end }}.css">
 		<link rel="stylesheet" href="{{ $baseUrl }}/css/bootstrap.min.css">
 		<link rel="stylesheet" href="{{ $baseUrl }}/css/bootstrap-theme.min.css">
 		<link rel="stylesheet" href="{{ $baseUrl }}/css/theme.css">
@@ -33,14 +33,14 @@
 			<div id="navbar" class="navbar-collapse collapse">
 				<ul class="nav navbar-nav">
 					<li {{ if eq $isHomePage true }}class="active"{{ end }}><a href="{{ $baseUrl }}/">Home</a></li>
-			{{ if isset .Site.Params "mainMenu" }}
+			{{ if .Site.Params.mainMenu }}
 				{{ $url := .Permalink }}
 				{{ range $menu := .Site.Params.mainMenu }}
 					{{ $itemUrl := printf "%s/%s/" $baseUrl $menu.link }}
 					<li {{ if eq $url $itemUrl }}class="active"{{ end }}><a href="{{ $baseUrl }}/{{ $menu.link }}">{{ $menu.name }}</a></li>
 				{{ end }}
 			{{ end }}
-				{{ if isset .Site.Params "noCategoryLink" }}{{ else }}
+				{{ if .Site.Params.noCategoryLink }}{{ else }}
 					<li class="dropdown">
 						<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Categories<span class="caret"></span></a>
 						<ul class="dropdown-menu" role="menu">


### PR DESCRIPTION
@ethanmad

I think this fixes #18 .
I tried this for my demo site locally with Hugo v0.18.1 and it works.

The problem also has affected following params:

- `noCategoryLink`
- `repositoryUrl`
- `highlightStyle`

including `mainMenu`.

Thanks,