### PR TITLE
Fix #20 / Use .IsHome and change way to detect active menu link

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -36,7 +36,7 @@
 			{{ $url := .Permalink }}
 			{{ with .Site.Params.mainMenu }}
 				{{ range $menu := . }}
-					{{ $itemUrl := printf "%s/%s/" $baseUrl $menu.link }}
+					{{ $itemUrl := printf "%s/%s" $baseUrl $menu.link }}
 					<li {{ if eq $url $itemUrl }}class="active"{{ end }}><a href="{{ $baseUrl }}/{{ $menu.link }}">{{ $menu.name }}</a></li>
 				{{ end }}
 			{{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 {{ $baseUrl := .Site.BaseURL }}
-{{ $isHomePage := eq .Title .Site.Title }}
 <html lang="en">
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link rel="alternate" href="/index.xml" type="application/rss+xml" title="{{ .Site.Title }}">
 		<link rel="icon" href="{{ $baseUrl }}/favicon.ico">
-		<title>{{ .Title }}{{ if eq $isHomePage false }} - {{ .Site.Title }}{{ end }}</title>
+		<title>{{ if not .IsHome }}{{ .Title }} - {{ end }}{{ .Site.Title }}</title>
 		<!--<link href="http://fonts.googleapis.com/css?family=PT+Sans:400,700" rel="stylesheet" type="text/css">-->
 		<link rel="stylesheet" href="{{ $baseUrl }}/css/highlight/{{ with .Site.Params.highlightStyle }}{{ . }}{{ else }}default{{ end }}.css">
 		<link rel="stylesheet" href="{{ $baseUrl }}/css/bootstrap.min.css">
@@ -32,7 +31,7 @@
 			</div>
 			<div id="navbar" class="navbar-collapse collapse">
 				<ul class="nav navbar-nav">
-					<li {{ if eq $isHomePage true }}class="active"{{ end }}><a href="{{ $baseUrl }}/">Home</a></li>
+					<li {{ if .IsHome }}class="active"{{ end }}><a href="{{ $baseUrl }}/">Home</a></li>
 			{{ $url := .Permalink }}
 			{{ with .Site.Params.mainMenu }}
 				{{ range $menu := . }}

--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "A simple Hugo theme with Bootstrap for documentation"
 homepage = "http://key-amb.github.io/bootie-docs-demo/"
 tags = ["document", "bootstrap"]
 features = ["document", ""]
-min_version = 0.14
+min_version = 0.15
 
 [author]
   name = "IKEDA Kiyoshi"


### PR DESCRIPTION
1. Thanks to @ethanmad , use `.IsHome` introduced in Hugo v0.15 to detect if current page is Home or not
   - See #20 
2. Change not to append trailing `/` by header.html
   - One should add `/` to `link` param of menu item if ze wants to match `xxx/` URL like below:

```toml
# config.toml
[[params.mainMenu]]
  name = "Index"
  link = "index/"
```

### Note

* I do 2nd change because I've noticed the link of _Index_ of demo site http://key-amb.github.io/bootie-docs-demo/ has broken.
* Another way to shoot #20 is here: https://github.com/key-amb/hugo-theme-bootie-docs/commit/0e9a6bcfdd6314cb0c0e6638c96c7ebc63d9758f
   * In this change, one have to change the `title` param of *_index.md*. I think this is rather confusing, so I don't take this approach.